### PR TITLE
simplify apply button layout

### DIFF
--- a/about.css
+++ b/about.css
@@ -195,34 +195,24 @@ a.class2:hover {
     
 }
 
+.apply-container {
+  display: flex;
+  position: relative;
+  justify-content: center;
+  align-items: center;
+}
+
 /* ellipse */
 
 .bgpic {
-  margin: auto;
-  max-height:100vh;
   max-width: 100vw;
-  margin-bottom: -4px;
-  margin-top: 50px;
-}
-
-.bgpic img {
-  max-height:100vh;
-  max-width: 100vw;
-
-}
-
-@media only screen and (max-width: 600px) {
-  .bgpic {
-    margin-top: 0px;
-  } 
+  max-height: 100vh;
 }
 
 /* apply */
 
 .subscribetext {
   position: absolute;
-  height: 420px;
-  width: 100%;
   max-width: 100%;
   color: #15402A;
   font-family: "Editorial New";
@@ -231,12 +221,9 @@ a.class2:hover {
   letter-spacing: 0;
   line-height: 76px;
   text-align: center;
-  margin-top: -35%;
 }
 
 a.class3 {
-  height: 420px;
-  width: 100%;
   color:#ffffff;
   -webkit-text-stroke-width: 0.5px;
   -webkit-text-stroke-color: #15402A;
@@ -257,14 +244,9 @@ a.class3:hover {
 }
 
 @media only screen and (max-width: 600px) {
-  .subscribetext {
-    margin-top: -40%;
-    max-height: 200px;
-  } 
-    a.class3 {
-      font-size: 100px;
-
-    }  
+  a.class3 {
+    font-size: 100px;
+  }  
 }
 
 /* newsletter */

--- a/about.html
+++ b/about.html
@@ -118,12 +118,11 @@
           </div>
       </article>
 
-      <!-- ellipse -->
-      <div class="bgpic"><img src="http://extramurosres.com/ellipse.png"></div>
-
-      <!-- apply -->
-      <div class="subscribetext">
-       <a href="http://extramuros.olivierduport.fr/apply" class="class3" target="_blank">Apply</a>
+      <div class="apply-container">
+        <!-- ellipse -->
+        <img class="bgpic" src="http://extramurosres.com/ellipse.png">
+        <!-- apply -->
+        <a href="http://extramuros.olivierduport.fr/apply" class="subscribetext class3" target="_blank">Apply</a>
       </div>
 
       <!-- newsletter -->


### PR DESCRIPTION
En général, si t'as un container qui ne contient qu'un seul élément, c'est plus pratique de ne garder que cet élément et virer le container. Avoir moins d'éléments html sur ta page permet de gérer le layout avec plus de facilité. Par contre, si t'as plusieurs éléments dont le layout depend les uns des autres, là la meilleur solution, c'est du grouper ces éléments dans une meme div.

Ici du coup, j'ai dégagé les divs autour de bgpic et du lien vers apply, j'ai filé la classe de ces divs à leurs enfants respectifs, puis j'ai créé une nouvelle div avec la classe `apply-container` dans laquelle j'ai placé la bgpic et le lien, directement.

Ensuite, j'ai fait en sorte que ce nouveau container soit `display: flex` avec son contenu centré en horizontal et vertical.

Pour le background, j'ai viré tout le css qui lui fixait une taille ou qui la déplaçait dans le layout, comme ça elle prend juste la taille disponible autour d'elle (grace a max-width et max-height) et sa position est uniquement controlée par .apply-container. 

Pour le lien, je l'ai mis en `position: absolute`. Comme apply-container est en `position: relative`, tous ses enfants en absolute se positionneront par défaut au meme endroit que le premier enfant sans `position: absolute`. Comme apply-container est flex et qu'il est censé centrer ses enfants, le lien se positionnera automatiquement au centre du container, par dessus l'image. Meme plus besoin de lui filer de margin ou de top/left, ça marche tout seul !